### PR TITLE
Feature/mocka treat deprecation

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -10,4 +10,5 @@ module.exports = {
     recursive: true,
     reporter: 'spec',
     timeout: 10000,
+    slow: 0,
 };

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// Here's a JavaScript-based config file.
+// If you need conditional logic, you might want to use this type of config.
+// Otherwise, JSON or YAML is recommended.
+
+module.exports = {
+    require: 'ts-node/register',
+    'watch-extensions': 'ts',
+    recursive: true,
+    reporter: 'spec',
+    timeout: 10000,
+};

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -2,7 +2,6 @@ import {expect, test} from '@oclif/test'
 
 describe('install', () => {
   test
-    .timeout(10000)
     .stdout()
     .command(['install'])
     .it('runs install', (ctx) => {

--- a/test/commands/join.test.ts
+++ b/test/commands/join.test.ts
@@ -41,7 +41,6 @@ describe('join', () => {
     })
 
   test
-    .timeout(10000)
     .stub(process, 'exit', () => 'foobar')
     .stderr()
     .command([

--- a/test/commands/join.test.ts
+++ b/test/commands/join.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable unicorn/no-process-exit, no-process-exit */
 import {expect, test} from '@oclif/test'
-import * as shell from 'shelljs'
-import * as path from 'path'
+// import * as shell from 'shelljs'
+// import * as path from 'path'
 
 describe('join', () => {
-  afterEach(function () {
-    shell.exec('git checkout -q -- test/files/*')
-  })
+  // afterEach(function () {
+  //   shell.exec('git checkout -q -- test/files/*')
+  // })
   const strJoin =
     '{"Profile":{"$":{"xmlns":"http://soap.sforce.com/2006/04/metadata"},"layoutAssignments":[{"layout":["Account-Account Layout"]},{"layout":["Account-Account Layout"],"recordType":["Account.Customer"]}],"userPermissions":[{"enabled":["false"],"name":["ViewSetup"]}]}}'
 
@@ -17,11 +17,11 @@ describe('join', () => {
     .command([
       'join',
       '-m',
-      path.join('.', 'test', 'files', 'ancestor.profile-meta.xml'),
+      './test/files/ancestor.profile-meta.xml',
       '-m',
-      path.join('.', 'test', 'files', 'ours.profile-meta.xml'),
+      './test/files/ours.profile-meta.xml',
       '-m',
-      path.join('.', 'test', 'files', 'theirs.profile-meta.xml'),
+      './test/files/theirs.profile-meta.xml',
       '-v',
     ])
     .it('runs join', (ctx) => {
@@ -46,11 +46,12 @@ describe('join', () => {
     .command([
       'join',
       '-m',
-      path
-        .join('.', 'test', 'files')
-        .toString()
-        .concat(path.sep)
-        .concat('non_existing.profile-meta.xml'),
+      './test/files/non_existing.profile-meta.xml',
+      // path
+      //   .join('.', 'test', 'files')
+      //   .toString()
+      //   .concat(path.sep)
+      //   .concat('non_existing.profile-meta.xml'),
     ])
     .it('runs join with inexisting file', (ctx) => {
       expect(process.exit()).to.equal('foobar')

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,0 @@
---require ts-node/register
---watch-extensions ts
---recursive
---reporter spec
---timeout 5000


### PR DESCRIPTION
migrate from mocka.opts which is deprecated to .mockarc.js
adapt options to treat limit timeout and show all times in report